### PR TITLE
Issue 71: Add loading component when looking up addres

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "lodash": "^4.17.5",
     "vue": "^2.3.3",
     "vue-router": "^2.6.0",
+    "vue-spinner": "^1.0.3",
     "whatwg-fetch": "^2.0.4"
   },
   "devDependencies": {

--- a/frontend/src/components/NashvilleZoneLookupHome.vue
+++ b/frontend/src/components/NashvilleZoneLookupHome.vue
@@ -194,10 +194,6 @@ $address-search-offset: 30px;
         background-color: $nashville-zone-lookup-blue;
         color: $light-text-color;
     }
-
-    .v-spinner {
-      background-color: $nashville-zone-lookup-blue !important;
-    }
 }
 
 

--- a/frontend/src/components/NashvilleZoneLookupHome.vue
+++ b/frontend/src/components/NashvilleZoneLookupHome.vue
@@ -49,6 +49,9 @@
         </div>
         <div class="container">
             <div class="row justify-content-center">
+                <!-- :color is $nashville-zone-lookup-blue -->
+                <pulse-loader :loading="loading" :color="'#1b355d'"></pulse-loader>
+                <div class="w-100"></div>
                 <div class="col-12  col-md-6">
                   <error-notification v-if="errorMessage" :message="errorMessage"></error-notification>
                 </div>
@@ -66,6 +69,7 @@
 <script>
   import FontAwesomeIcon from '@fortawesome/vue-fontawesome'
   import faSearch from '@fortawesome/fontawesome-free-solid/faSearch'
+  import PulseLoader from 'vue-spinner/src/PulseLoader.vue'
 
   import NashvilleZoneLookupApiClient from '@/client'
   import ErrorNotification from './ErrorNotification.vue'
@@ -79,6 +83,7 @@
         category: null,
         errorMessage: null,
         landUseCategories: [],
+        loading: false,
         searchIcon: faSearch,
         summary: null
       }
@@ -100,6 +105,9 @@
           return
         }
 
+        this.loading = true
+        this.errorMessage = null
+
         NashvilleZoneLookupApiClient
           .getLandUseSummaryForAddress(address)
           .then(resp => Promise.all([resp, resp.json()]))
@@ -116,6 +124,9 @@
             console.error(err)
             this.errorMessage = 'Unknown server error - please try again later.'
           })
+          .finally(() => {
+            this.loading = false
+          })
       },
 
       onCategorySelected (category) {
@@ -131,6 +142,7 @@
       ErrorNotification,
       FontAwesomeIcon,
       LandUseSummary,
+      PulseLoader,
       UseCategoryDropdown
     },
 
@@ -181,6 +193,10 @@ $address-search-offset: 30px;
     .AddressSearchButton {
         background-color: $nashville-zone-lookup-blue;
         color: $light-text-color;
+    }
+
+    .v-spinner {
+      background-color: $nashville-zone-lookup-blue !important;
     }
 }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7227,6 +7227,10 @@ vue-router@^2.6.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-2.8.1.tgz#9833c9ee57ac83beb0269056fefee71713f20695"
 
+vue-spinner@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/vue-spinner/-/vue-spinner-1.0.3.tgz#eecd3f79f63a815b690e9d54b199ab65be695499"
+
 vue-style-loader@^3.0.0, vue-style-loader@^3.0.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-3.1.2.tgz#6b66ad34998fc9520c2f1e4d5fa4091641c1597a"


### PR DESCRIPTION
This uses [vue-spinner PulseLoader](http://greyby.github.io/vue-spinner/) (which looks like an ellipsis ...) whenever a user presses enter to start a search.  It is centered just below the search bar, and is removed whenever the request for information completes.

![laoding](https://user-images.githubusercontent.com/4812055/39669943-1cd7e036-50bf-11e8-89a0-34aa08e596db.gif)

Closes #71 